### PR TITLE
Updates To Fix Runtime Errors

### DIFF
--- a/runsharp/full_gui.py
+++ b/runsharp/full_gui.py
@@ -1203,7 +1203,7 @@ def search_and_plotDB(model, station, datetime, close=True, output='./'):
 
     string = OKGREEN + "Creating image for station %s using data source %s at time %s ..." + ENDC
     print( string % (station, model, datetime.strftime('%Y%m%d/%H%M')))
-    main_win.picker.skew.spc_widget.pixmapToFile(output + datetime.strftime('%Y%m%d.%H%M_' + model + '.png'))
+    main_win.picker.skew.spc_widget.pixmapToFile(output + datetime.strftime('%Y%m%d.%H%M_') + station + '_' + model + '.png')
     if close:
         main_win.picker.skew.close()
     return main_win

--- a/sharppy/databases/pwv.py
+++ b/sharppy/databases/pwv.py
@@ -61,7 +61,7 @@ def get_mean_pwv(station):
     else:
         station_idx = station_idx + 1
         ## get the PWV
-        mean_pwv = pwv_means[station_idx, 3:][0].astype(np.float)
+        mean_pwv = pwv_means[station_idx, 3:][0].astype(float)
     return mean_pwv
 
 def get_stdev_pwv(station):
@@ -111,7 +111,7 @@ def get_stdev_pwv(station):
     else:
         station_idx = station_idx + 1
         ## get the PWV
-        stdev_pwv = pwv_stdevs[station_idx, 3:][0].astype(np.float)
+        stdev_pwv = pwv_stdevs[station_idx, 3:][0].astype(float)
     return stdev_pwv
 
 def pwv_climo(prof, station, month=None):

--- a/sharppy/io/spc_decoder.py
+++ b/sharppy/io/spc_decoder.py
@@ -41,7 +41,7 @@ class SPCDecoder(Decoder):
             lat = 35.
             lon = -97.
 
-        if time > datetime.now(timezone.utc) + timedelta(hours=1): 
+        if time > (datetime.utcnow() + timedelta(hours=1)): 
             # If the strptime accidently makes the sounding in the future (like with SARS archive)
             # i.e. a 1957 sounding becomes 2057 sounding...ensure that it's a part of the 20th century
             time = datetime.strptime('19' + data_header[1][:11], '%Y%m%d/%H%M')

--- a/sutils/async_threads.py
+++ b/sutils/async_threads.py
@@ -7,7 +7,7 @@ except ImportError:
     import queue as Queue
 import logging
 import hashlib
-from datetime import datetime
+from datetime import datetime, timezone
 import traceback
 
 class AsyncThreads(QObject):


### PR DESCRIPTION
- Adds missing timezone import to [sutils/async_threads.py](https://github.com/NUCAPS/SHARPpy/compare/main...HumphreysCarter:SHARPpy:main#diff-3a463caac634493cf16072918c584984df264d0af17236ba6486f949d11b896a) as mentioned in #4.
- Replace np.float with float in [sharppy/databases/pwv.py](https://github.com/NUCAPS/SHARPpy/compare/main...HumphreysCarter:SHARPpy:main#diff-ae79eae6d755fb51b6907f00c31c98b3a32d1302edfd97dc79ffd3fd667dfe27) since np.float was deprecated in NumPy 1.20.
- Replaced datetime.now with datetime.utcnow in [sutils/async_threads.py](https://github.com/NUCAPS/SHARPpy/compare/main...HumphreysCarter:SHARPpy:main#diff-3a463caac634493cf16072918c584984df264d0af17236ba6486f949d11b896a) to fix issue with comparing non-timezone aware dates. 